### PR TITLE
Fix initialization on fabric servers

### DIFF
--- a/Fabric/src/main/java/ram/talia/hexal/fabric/FabricHexalClientInitializer.kt
+++ b/Fabric/src/main/java/ram/talia/hexal/fabric/FabricHexalClientInitializer.kt
@@ -1,16 +1,21 @@
 package ram.talia.hexal.fabric
 
 import net.fabricmc.api.ClientModInitializer
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents
 import net.fabricmc.fabric.api.client.rendering.v1.BlockEntityRendererRegistry
 import net.minecraft.client.renderer.blockentity.BlockEntityRendererProvider
 import net.minecraft.world.level.block.entity.BlockEntity
 import net.minecraft.world.level.block.entity.BlockEntityType
+import ram.talia.hexal.client.LinkablePacketHolder
 import ram.talia.hexal.client.RegisterClientStuff
 import ram.talia.hexal.fabric.network.FabricPacketHandler
 
 object FabricHexalClientInitializer : ClientModInitializer {
     override fun onInitializeClient() {
         FabricPacketHandler.initClientBound()
+
+        // reattempt link render packets that failed to apply properly once every 20 ticks.
+        ClientTickEvents.START_CLIENT_TICK.register { LinkablePacketHolder.maybeRetry() }
 
         RegisterClientStuff.init()
 

--- a/Fabric/src/main/java/ram/talia/hexal/fabric/FabricHexalInitializer.kt
+++ b/Fabric/src/main/java/ram/talia/hexal/fabric/FabricHexalInitializer.kt
@@ -38,9 +38,6 @@ object FabricHexalInitializer : ModInitializer {
     }
 
     private fun initListeners() {
-        // reattempt link render packets that failed to apply properly once every 20 ticks.
-        ClientTickEvents.START_CLIENT_TICK.register { LinkablePacketHolder.maybeRetry() }
-
         ServerLifecycleEvents.SERVER_STARTED.register {
             val savedData = it.overworld().dataStorage.computeIfAbsent(::GateSavedData, ::GateSavedData, FILE_GATE_MANAGER)
             savedData.setDirty()


### PR DESCRIPTION
This fixes a bug where hexal was trying register a client tick event on fabric servers. I simply moved ``ClientTickEvents.START_CLIENT_TICK.register { LinkablePacketHolder.maybeRetry() }`` from ``FabricHexalInitializer`` to ``FabricHexalClientInitializer``

This resolves the following error:

```
[main/ERROR]: Failed to start the minecraft server
java.lang.RuntimeException: Could not execute entrypoint stage 'main' due to errors, provided by 'hexal'!
at net.fabricmc.loader.impl.entrypoint.EntrypointUtils.lambda$invoke0$0(EntrypointUtils.java:51) ~[fabric-loader-0.14.13.jar:?]
at net.fabricmc.loader.impl.util.ExceptionUtil.gatherExceptions(ExceptionUtil.java:33) ~[fabric-loader-0.14.13.jar:?]
at net.fabricmc.loader.impl.entrypoint.EntrypointUtils.invoke0(EntrypointUtils.java:49) ~[fabric-loader-0.14.13.jar:?]
at net.fabricmc.loader.impl.entrypoint.EntrypointUtils.invoke(EntrypointUtils.java:35) ~[fabric-loader-0.14.13.jar:?]
at net.fabricmc.loader.impl.game.minecraft.Hooks.startServer(Hooks.java:62) ~[fabric-loader-0.14.13.jar:?]
at net.minecraft.server.Main.main(Main.java:101) [server-intermediary.jar:?]
at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:461) [fabric-loader-0.14.13.jar:?]
at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74) [fabric-loader-0.14.13.jar:?]
at net.fabricmc.loader.impl.launch.knot.KnotServer.main(KnotServer.java:23) [fabric-loader-0.14.13.jar:?]
at net.fabricmc.loader.impl.launch.server.FabricServerLauncher.main(FabricServerLauncher.java:69) [fabric-loader-0.14.13.jar:?]
at net.fabricmc.installer.ServerLauncher.main(ServerLauncher.java:69) [fabric-server-launcher.jar:0.11.1]
Caused by: java.lang.RuntimeException: Cannot load class net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents in environment type SERVER
at net.fabricmc.loader.impl.transformer.FabricTransformer.transform(FabricTransformer.java:59) ~[fabric-loader-0.14.13.jar:?]
at net.fabricmc.loader.impl.launch.knot.KnotClassDelegate.getPreMixinClassByteArray(KnotClassDelegate.java:462) ~[fabric-loader-0.14.13.jar:?]
at net.fabricmc.loader.impl.launch.knot.KnotClassDelegate.getPostMixinClassByteArray(KnotClassDelegate.java:415) ~[fabric-loader-0.14.13.jar:?]
at net.fabricmc.loader.impl.launch.knot.KnotClassDelegate.tryLoadClass(KnotClassDelegate.java:323) ~[fabric-loader-0.14.13.jar:?]
at net.fabricmc.loader.impl.launch.knot.KnotClassDelegate.loadClass(KnotClassDelegate.java:218) ~[fabric-loader-0.14.13.jar:?]
at net.fabricmc.loader.impl.launch.knot.KnotClassLoader.loadClass(KnotClassLoader.java:112) ~[fabric-loader-0.14.13.jar:?]
at java.lang.ClassLoader.loadClass(ClassLoader.java:520) ~[?:?]
at ram.talia.hexal.fabric.FabricHexalInitializer.initListeners(FabricHexalInitializer.kt:42) ~[hexal-fabric-1.19.2-0.2.7.jar:?]
at ram.talia.hexal.fabric.FabricHexalInitializer.onInitialize(FabricHexalInitializer.kt:33) ~[hexal-fabric-1.19.2-0.2.7.jar:?]
at net.fabricmc.loader.impl.entrypoint.EntrypointUtils.invoke0(EntrypointUtils.java:47) ~[fabric-loader-0.14.13.jar:?]
... 8 more
```