### PR TITLE
Fix 0.2.14 docgen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ Session.vim
 plot/
 
 doc/out.html
+doc/__pycache__/

--- a/doc/collate_data.py
+++ b/doc/collate_data.py
@@ -195,7 +195,7 @@ def do_format(root_data, obj, *names):
 def identity(x): return x
 
 pattern_pat = re.compile(r'HexPattern\.fromAngles\("([qweasd]+)", HexDir\.(\w+)\),\s*modLoc\("([^"]+)"\)(?:[^val]*[^\(](true)\))?')
-pattern_stubs = [(None, "ram/talia/hexal/common/casting/Patterns.kt")]
+pattern_stubs = [(None, "ram/talia/hexal/common/casting/Patterns.kt"), ("Fabric", "ram/talia/hexal/fabric/FabricHexalInitializer.kt")]
 def fetch_patterns(root_data):
 	registry = {}
 	for loader, stub in pattern_stubs:


### PR DESCRIPTION
The docgen script was crashing because it couldn't find `interop/fabric_only/phase_block`. This adds `FabricHexalInitializer.kt` to the list of pattern stubs in the docgen to fix that. This is the same way Hex handles Fabric-only patterns (thanks @Cypher121 for pointing this out).
I also added `doc/__pycache__/` to the gitignore because Python generates them automatically, they're not supposed to be checked out, and the Git message was bugging me. :)