### PR TITLE
Update pattern regex to properly detect great spells in all cases

### DIFF
--- a/doc/collate_data.py
+++ b/doc/collate_data.py
@@ -194,7 +194,10 @@ def do_format(root_data, obj, *names):
 
 def identity(x): return x
 
-pattern_pat = re.compile(r'HexPattern\.fromAngles\("([qweasd]+)", HexDir\.(\w+)\),\s*modLoc\("([^"]+)"\)(?:[^val]*[^\(](true)\))?')
+pattern_pat = re.compile(
+	r'HexPattern\.fromAngles\("([qweasd]+)", HexDir\.(\w+)\),\s*modLoc\("([^"]+)"\),[^,]+?(?:makeConstantOp|Op\w+).*?(\btrue)?\)(?:[^\)]+?\bval\b|(?:(?!\bval\b)(?:.))+$)',
+    re.S,
+)
 pattern_stubs = [(None, "ram/talia/hexal/common/casting/Patterns.kt"), ("Fabric", "ram/talia/hexal/fabric/FabricHexalInitializer.kt")]
 def fetch_patterns(root_data):
 	registry = {}


### PR DESCRIPTION
Fixes the following issue initially reported on Discord. Tested by running HexBug's registry script and comparing the output to before this change was made, and by running the docgen and skimming out.html.
![image](https://github.com/Talia-12/Hexal/assets/37044997/37705a88-3836-45ac-843a-99b38171ea55)
