### PR TITLE
SerializedIotas performance improvements and stack/ravenmind oversize handling.

### DIFF
--- a/Common/src/main/java/ram/talia/hexal/api/linkable/ServerLinkableHolder.kt
+++ b/Common/src/main/java/ram/talia/hexal/api/linkable/ServerLinkableHolder.kt
@@ -27,7 +27,7 @@ class ServerLinkableHolder(private val thisLinkable: ILinkable, private val leve
     /**
      * Initialise to [SerialisedIotaList] (null)
      */
-    private val serReceivedIotas = SerialisedIotaList(null)
+    private val serReceivedIotas = SerialisedIotaList()
 
     private fun addRenderLink(other: ILinkable) {
         lazyRenderLinks.get().add(other)
@@ -92,7 +92,7 @@ class ServerLinkableHolder(private val thisLinkable: ILinkable, private val leve
         // clear entities that have been removed from the world at least once per second
         // to prevent any memory leak type errors
         if (level.gameTime % 20 == 0L)
-            serReceivedIotas.refresh()
+            serReceivedIotas.refreshIotas(level)
 
         for (i in (linked.size - 1) downTo 0) {
             if (linked[i].shouldRemove() || !thisLinkable.isInRange(linked[i]))
@@ -102,19 +102,19 @@ class ServerLinkableHolder(private val thisLinkable: ILinkable, private val leve
 
     fun receiveIota(iota: Iota) {
         if (numRemainingIota() < ILinkable.MAX_RECEIVED_IOTAS)
-            serReceivedIotas.add(iota, level)
+            serReceivedIotas.add(iota)
     }
 
     fun nextReceivedIota() = serReceivedIotas.pop(level) ?: NullIota()
 
-    fun numRemainingIota() = serReceivedIotas.size
+    fun numRemainingIota() = serReceivedIotas.size()
 
     fun clearReceivedIotas() {
-        serReceivedIotas.tag = ListTag()
+        serReceivedIotas.clear()
     }
 
     fun allReceivedIotas(): List<Iota> {
-        return serReceivedIotas.get(level)
+        return serReceivedIotas.getIotas(level)
     }
 
     /**
@@ -124,7 +124,7 @@ class ServerLinkableHolder(private val thisLinkable: ILinkable, private val leve
         val tag = CompoundTag()
         tag.put(TAG_LINKED, lazyLinked.getUnloaded())
         tag.put(TAG_RENDER_LINKED, lazyRenderLinks.getUnloaded())
-        serReceivedIotas.tag?.let { tag.put(TAG_RECEIVED, it) }
+        tag.put(TAG_RECEIVED, serReceivedIotas.getTag())
         return tag
     }
 
@@ -142,7 +142,10 @@ class ServerLinkableHolder(private val thisLinkable: ILinkable, private val leve
             else -> lazyRenderLinks.set(renderLinkedTag)
         }
 
-        serReceivedIotas.tag = tag.get(TAG_RECEIVED) as? ListTag
+        when (val receivedTag = tag.get(TAG_RECEIVED) as? ListTag) {
+            null -> serReceivedIotas.clear()
+            else -> serReceivedIotas.set(receivedTag)
+        }
     }
 
     companion object {

--- a/Common/src/main/java/ram/talia/hexal/api/nbt/SerialisedIotas.kt
+++ b/Common/src/main/java/ram/talia/hexal/api/nbt/SerialisedIotas.kt
@@ -4,83 +4,453 @@ import at.petrak.hexcasting.api.spell.iota.EntityIota
 import at.petrak.hexcasting.api.spell.iota.Iota
 import at.petrak.hexcasting.api.spell.iota.ListIota
 import at.petrak.hexcasting.api.spell.iota.NullIota
+import at.petrak.hexcasting.api.utils.asCompound
+import at.petrak.hexcasting.api.utils.downcast
 import at.petrak.hexcasting.common.lib.hex.HexIotaTypes
-import com.mojang.datafixers.util.Either
+import at.petrak.hexcasting.common.lib.hex.HexIotaTypes.getTypeFromTag
 import net.minecraft.nbt.CompoundTag
 import net.minecraft.nbt.ListTag
+import net.minecraft.nbt.NbtUtils
 import net.minecraft.server.level.ServerLevel
+import net.minecraft.world.entity.Entity
+import java.util.*
 
-class SerialisedIota(private var tagOrIota: Either<CompoundTag, Iota>?) {
-    var tag: CompoundTag?
-        get() = tagOrIota?.map({ it }, { HexIotaTypes.serialize(it) })
-        set(value) { tagOrIota = Either.left(value) }
 
-    fun set(iota: Iota) {
-        tagOrIota = Either.right(iota)
+class SerialisedIotaList(private var tag: ListTag?, private var iotas: MutableList<Iota>?) {
+    /*
+     * Most of the time this will operate as a smart caching layer for an iota list that is stored in a tag.
+     *
+     * If it is given a raw iota list instead, then it will operate without the serialized version for as long as
+     * possible. If required it will promote the raw iota list to a serialized one and revert to the other behavior.
+     * */
+
+    constructor(iotas: MutableList<Iota>?) : this(null, iotas)
+    constructor(tag: ListTag?) : this(tag, null)
+
+    constructor() : this(null, null)
+
+    private var level: ServerLevel? = null
+    private var tagReferencedEntityUUIDs: MutableList<UUID>? = null
+    private var tagReferencedEntitiesAreLoaded: MutableList<Boolean>? = null
+
+    private var iotasReferencedEntities: MutableList<Entity>? = null
+
+    private fun scanIotaForEntities(iota: Iota, entityList: MutableList<Entity>)
+    {
+        when (iota.type) {
+            HexIotaTypes.ENTITY -> {
+                val entity = (iota as EntityIota).entity
+                if (!entityList.contains(entity)) {
+                    entityList.add(entity)
+                }
+            }
+            HexIotaTypes.LIST -> {
+                for (subIota in (iota as ListIota).list)
+                {
+                    scanIotaForEntities(subIota, entityList)
+                }
+            }
+        }
     }
 
-    fun get(level: ServerLevel): Iota? = tagOrIota?.map({ HexIotaTypes.deserialize(it, level) }, { mapIotaStillValid(it) })
+    private fun scanTagForEntities(tag: CompoundTag, referencedEntityUUIDs: MutableList<UUID>)
+    {
+        val type = getTypeFromTag(tag) ?: return
+        val data = tag[HexIotaTypes.KEY_DATA] ?: return
 
-    fun copy(serIota: SerialisedIota) {
-        tagOrIota = serIota.tagOrIota?.mapBoth({ it.copy() }, { it })
+        when (getTypeFromTag(tag)) {
+            HexIotaTypes.ENTITY -> {
+                val uuidTag = data.downcast(CompoundTag.TYPE)["uuid"] ?: return
+                val uuid = NbtUtils.loadUUID(uuidTag)
+                if (!referencedEntityUUIDs.contains(uuid)) {
+                    referencedEntityUUIDs.add(uuid)
+                }
+            }
+            HexIotaTypes.LIST -> {
+                val listTag = data.downcast(ListTag.TYPE)
+                for (sub in listTag) {
+                    scanTagForEntities(sub.downcast(CompoundTag.TYPE), referencedEntityUUIDs)
+                }
+            }
+        }
     }
 
-    fun refresh() {
-        tagOrIota = tagOrIota?.mapRight { mapIotaStillValid(it) }
-    }
-}
-
-class SerialisedIotaList(private var tagOrIotas: Either<ListTag, List<Iota>>?) {
-    var tag: ListTag?
-        get() = tagOrIotas?.map({ it }, { it.toNbtList() })
-        set(value) { tagOrIotas = Either.left(value) }
-
-    fun set(iotas: List<Iota>) {
-        tagOrIotas = Either.right(iotas)
+    fun clear() {
+        iotas = null
+        tag = null
+        level = null
+        tagReferencedEntityUUIDs = null
+        tagReferencedEntitiesAreLoaded = null
+        iotasReferencedEntities = null
     }
 
-    fun get(level: ServerLevel): List<Iota> = tagOrIotas?.map({ it.toIotaList(level) }, { mapIotaListStillValid(it) }) ?: mutableListOf()
+    fun set(iotas: MutableList<Iota>) {
+        this.iotas = iotas
 
-    fun add(iota: Iota, level: ServerLevel) {
-        val iotas = get(level).toMutableList()
-        iotas.add(iota)
-        set(iotas)
+        // Invalidate caches
+        tag = null
+        level = null
+        tagReferencedEntityUUIDs = null
+        tagReferencedEntitiesAreLoaded = null
+        iotasReferencedEntities = null
+    }
+
+    fun set(tag: ListTag) {
+        this.tag = tag
+
+        // Invalidate caches
+        level = null
+        iotas = null
+        tagReferencedEntityUUIDs = null
+        tagReferencedEntitiesAreLoaded = null
+        iotasReferencedEntities = null
+    }
+
+    fun refreshIotas(level: ServerLevel) {
+        if (tag != null)
+        {
+            // We have a tag to use as master for the cached iota list
+
+            var regenerateCache = (iotas == null) || (this.level != level)
+
+            // Scan entities for changes in the loaded set
+            if (tagReferencedEntityUUIDs != null)
+            {
+                for (i in 0 until tagReferencedEntityUUIDs!!.size)
+                {
+                    val uuid = tagReferencedEntityUUIDs!![i]
+                    val entityIsLoaded = tagReferencedEntitiesAreLoaded!![i]
+                    val entity = level.getEntity(uuid)
+                    if ((entity != null) != entityIsLoaded)
+                    {
+                        regenerateCache = true
+                        break
+                    }
+                }
+            }
+
+            if (regenerateCache)
+            {
+                tagReferencedEntityUUIDs = ArrayList()
+                tagReferencedEntitiesAreLoaded = ArrayList()
+                this.level = level
+                iotas = tag?.toIotaList(level) ?: mutableListOf()
+
+                // Update referencedEntityUUIDs and referencedEntitiesAreLoaded
+                if (tag != null)
+                {
+                    for (innerTag in tag!!)
+                    {
+                        scanTagForEntities(innerTag.asCompound, tagReferencedEntityUUIDs!!)
+                    }
+                }
+
+                for (uuid in tagReferencedEntityUUIDs!!)
+                {
+                    tagReferencedEntitiesAreLoaded!!.add(level.getEntity(uuid) != null)
+                }
+            }
+        }
+        else if (iotas != null)
+        {
+            // We have no tag, but we have iotas
+
+            // Scan iota list for removed entities
+            if (iotasReferencedEntities == null)
+            {
+                iotasReferencedEntities = ArrayList()
+                for (iota in iotas!!)
+                {
+                    scanIotaForEntities(iota, iotasReferencedEntities!!)
+                }
+            }
+
+            // If some entities have been removed, then force serialization so we don't loose the reference
+            var forceSerialize = false;
+            for (entity in iotasReferencedEntities!!)
+            {
+                if (entity.isRemoved)
+                {
+                    forceSerialize = true;
+                    break;
+                }
+            }
+
+            if (forceSerialize)
+            {
+                // Serialize so that removed entities are preserved, and deserialize to null them from the read list
+                tag = iotas!!.toNbtList()
+                // Abbreviated cache regeneration
+                iotas = tag!!.toIotaList(level)
+                this.level = level;
+
+                // Invalidate caches
+                iotasReferencedEntities = null
+                tagReferencedEntityUUIDs = null
+                tagReferencedEntitiesAreLoaded = null
+            }
+        }
+    }
+
+    fun getIotas(level: ServerLevel): List<Iota> {
+        refreshIotas(level)
+        return iotas ?: mutableListOf()
+    }
+
+    fun getTag(): ListTag {
+        if ((tag == null) && (iotas != null))
+        {
+            // We have an iota list, but no tag list. Time to promote the iotas to tags.
+            tag = iotas!!.toNbtList()
+
+            // Invalidate all other caches
+            iotas = null
+            level = null
+            iotasReferencedEntities = null
+            tagReferencedEntityUUIDs = null
+            tagReferencedEntitiesAreLoaded = null
+        }
+        return tag ?: ListTag()
+    }
+
+    fun add(iota: Iota) {
+        if (tag != null)
+        {
+            // Modify serialized version and invalidate cache
+            val newTag = HexIotaTypes.serialize(iota)
+            tag!!.add(newTag)
+
+            // Invalidate caches
+            this.level = null
+            iotas = null
+            tagReferencedEntityUUIDs = null
+            tagReferencedEntitiesAreLoaded = null
+            iotasReferencedEntities = null
+        }
+        else if (iotas != null)
+        {
+            // Modify deserialized version
+            iotas!!.add(iota)
+
+            // Invalidate cache
+            iotasReferencedEntities = null
+        }
+        else {
+            // Build new iota list
+            iotas = mutableListOf(iota)
+
+            // Everything else should be null at this point too, so no need to invalidate cache
+        }
+    }
+
+    fun add(tag: CompoundTag) {
+        if (this.tag != null)
+        {
+            // Modify serialized version and invalidate cache
+            this.tag!!.add(tag)
+
+            // Invalidate caches
+            this.level = null
+            iotas = null
+            tagReferencedEntityUUIDs = null
+            tagReferencedEntitiesAreLoaded = null
+            iotasReferencedEntities = null
+        }
+        else if (iotas != null)
+        {
+            // Promote deserialized version to serialized
+            this.tag = iotas!!.toNbtList()
+
+            // Add tag
+            this.tag!!.add(tag)
+
+            // Invalidate cache
+            this.level = null
+            iotas = null
+            iotasReferencedEntities = null
+            tagReferencedEntityUUIDs = null
+            tagReferencedEntitiesAreLoaded = null
+        }
+        else {
+            // Build new serialized list
+            this.tag = ListTag()
+            this.tag!!.add(tag)
+
+            // Everything else should be null at this point too, so no need to invalidate cache
+        }
     }
 
     fun pop(level: ServerLevel): Iota? {
-        if (size == 0)
+        if (tag != null)
+        {
+            // Modify serialized version and invalidate cache
+
+            if (tag!!.size == 0)
+            {
+                return null
+            }
+
+            val poppedTag = tag!!.removeAt(0)
+
+            // Invalidate caches
+            this.level = null
+            iotas = null
+            tagReferencedEntityUUIDs = null
+            tagReferencedEntitiesAreLoaded = null
+            iotasReferencedEntities = null
+
+            // If the list is now empty, decay to fully null (and un-opinionated between serialized/deserialized modes)
+            if (tag!!.size == 0)
+            {
+                this.tag = null;
+            }
+
+            return HexIotaTypes.deserialize(poppedTag.asCompound, level)
+        }
+        else if (iotas != null)
+        {
+            if (iotas!!.size == 0)
+            {
+                return null
+            }
+
+            // Modify deserialized version
+            val poppedIota = iotas!!.removeAt(0)
+
+            // Invalidate cache
+            iotasReferencedEntities = null
+
+            return poppedIota
+        }
+        else
+        {
             return null
-
-        val iotas = get(level).toMutableList()
-        val iota = iotas.removeFirst()
-        set(iotas)
-        return iota
+        }
     }
 
-    val size: Int
-        get() = tagOrIotas?.map({ it.size }, { it.size }) ?: 0
+    fun size(): Int {
+        return if (tag != null)
+        {
+            tag!!.size
+        }
+        else if (iotas!= null)
+        {
+            iotas!!.size
+        }
+        else {
+            0
+        }
+    }
 
+    fun getReferencedEntities(level: ServerLevel): List<Entity> {
+        if (tag != null)
+        {
+            if (tagReferencedEntityUUIDs == null)
+            {
+                tagReferencedEntityUUIDs = ArrayList()
+                tagReferencedEntitiesAreLoaded = ArrayList()
+                for (innerTag in tag!!)
+                {
+                    scanTagForEntities(innerTag.asCompound, tagReferencedEntityUUIDs!!)
+                }
+
+                for (uuid in tagReferencedEntityUUIDs!!)
+                {
+                    tagReferencedEntitiesAreLoaded!!.add(level.getEntity(uuid) != null)
+                }
+            }
+            var referencedEntities: MutableList<Entity> = ArrayList()
+            for (uuid in tagReferencedEntityUUIDs!!)
+            {
+                val entity = level.getEntity(uuid)
+                if (entity!= null)
+                    referencedEntities.add(entity)
+            }
+
+            return referencedEntities;
+        }
+        else if (iotas!= null)
+        {
+            if (iotasReferencedEntities == null)
+            {
+                iotasReferencedEntities = ArrayList()
+                for (iota in iotas!!)
+                {
+                    scanIotaForEntities(iota, iotasReferencedEntities!!)
+                }
+            }
+            return iotasReferencedEntities as List<Entity>;
+        }
+        else {
+            return ArrayList()
+        }
+    }
+/*
     fun copy(serIotaList: SerialisedIotaList) {
-        tagOrIotas = serIotaList.tagOrIotas?.mapBoth({ it.copy() }, { it })
-    }
+        tag = serIotaList.tag?.copy()
 
-    fun refresh() {
-        tagOrIotas = tagOrIotas?.mapRight { mapIotaListStillValid(it) }
-    }
+        // Invalidate cache
+        level = null
+        iotas = null
+        tagReferencedEntityUUIDs = null
+        tagReferencedEntitiesAreLoaded = null
+    }*/
 }
 
-/**
- * Takes an iota, and returns that iota with any [EntityIota]s whose entities no longer exist set to null.
- */
-fun mapIotaStillValid(iota: Iota): Iota = when (iota) {
-    is ListIota -> ListIota(mapIotaListStillValid(iota.list.toList()))
-    is EntityIota -> if (iota.entity.isRemoved) NullIota() else iota
-    else -> iota
-}
+// Wrapper for SerializedIotaList (only ever used for ravenmind)
+class SerialisedIota(private val iotaList: SerialisedIotaList = SerialisedIotaList(null, null)) {
 
-/**
- * Takes a list of iotas, and returns that list with any [EntityIota]s whose entities no longer exist set to null.
- */
-fun mapIotaListStillValid(iotas: List<Iota>): List<Iota> {
-    return iotas.map { mapIotaStillValid(it) }
+    constructor(iota: Iota?) : this(SerialisedIotaList(if (iota == null) null else mutableListOf(iota)))
+    constructor(tag: CompoundTag?) : this(SerialisedIotaList())
+    {
+        if (tag != null)
+        {
+            iotaList.add(tag)
+        }
+    }
+
+    constructor() : this(SerialisedIotaList())
+
+    fun getTag() : CompoundTag {
+        val listTag = iotaList.getTag()
+        return if (listTag.size == 0)
+        {
+            HexIotaTypes.serialize(NullIota())
+        }
+        else
+        {
+            listTag[0].asCompound
+        }
+    }
+
+    fun getIota(level: ServerLevel) : Iota {
+        val iotas = iotaList.getIotas(level)
+        return if (iotas.isEmpty())
+        {
+            NullIota()
+        }
+        else
+        {
+            iotas[0]
+        }
+    }
+
+    fun set(iota: Iota) {
+        iotaList.set(mutableListOf(iota))
+    }
+
+    fun set(tag: CompoundTag) {
+        val listTag = ListTag()
+        listTag.add(tag)
+        iotaList.set(listTag)
+    }
+
+    fun getReferencedEntities(level: ServerLevel) : List<Entity> {
+        return iotaList.getReferencedEntities(level)
+    }
+
+    fun refreshIota(level: ServerLevel)
+    {
+        iotaList.refreshIotas(level)
+    }
 }

--- a/Common/src/main/java/ram/talia/hexal/common/casting/actions/spells/wisp/OpSummonWisp.kt
+++ b/Common/src/main/java/ram/talia/hexal/common/casting/actions/spells/wisp/OpSummonWisp.kt
@@ -66,7 +66,7 @@ class OpSummonWisp(val ticking: Boolean) : SpellAction {
                 false -> ProjectileWisp(ctx.world, pos, vel, ctx.caster, media)
             }
             wisp.setColouriser(colouriser)
-            wisp.setHex(hex)
+            wisp.setHex(hex.toMutableList())
             ctx.world.addFreshEntity(wisp)
         }
     }

--- a/Common/src/main/java/ram/talia/hexal/common/casting/actions/spells/wisp/OpWispHex.kt
+++ b/Common/src/main/java/ram/talia/hexal/common/casting/actions/spells/wisp/OpWispHex.kt
@@ -19,6 +19,6 @@ object OpWispHex : ConstMediaAction {
 		if (wisp.caster != ctx.caster)
 			throw MishapOthersWisp(wisp.caster)
 
-		return wisp.serHex.get(ctx.world).asActionResult
+		return wisp.serHex.getIotas(ctx.world).asActionResult
 	}
 }

--- a/Common/src/main/java/ram/talia/hexal/common/entities/ProjectileWisp.kt
+++ b/Common/src/main/java/ram/talia/hexal/common/entities/ProjectileWisp.kt
@@ -2,6 +2,7 @@ package ram.talia.hexal.common.entities
 
 import at.petrak.hexcasting.api.spell.Action
 import at.petrak.hexcasting.api.spell.iota.EntityIota
+import at.petrak.hexcasting.api.spell.iota.NullIota
 import at.petrak.hexcasting.api.spell.iota.Vec3Iota
 import net.minecraft.world.entity.Entity
 import net.minecraft.world.entity.EntityType
@@ -14,6 +15,7 @@ import net.minecraft.world.phys.BlockHitResult
 import net.minecraft.world.phys.EntityHitResult
 import net.minecraft.world.phys.HitResult
 import net.minecraft.world.phys.Vec3
+import ram.talia.hexal.api.nbt.SerialisedIota
 import ram.talia.hexal.api.nbt.SerialisedIotaList
 import ram.talia.hexal.api.nbt.toNbtList
 import ram.talia.hexal.api.plus
@@ -109,7 +111,7 @@ open class ProjectileWisp : BaseCastingWisp {
 			playTrailParticles()
 		else {
 			val serStack = SerialisedIotaList(mutableListOf(EntityIota(this), EntityIota(result.entity)).toNbtList())
-			scheduleCast(CASTING_SCHEDULE_PRIORITY, serHex, serStack)
+			scheduleCast(CASTING_SCHEDULE_PRIORITY, serHex, serStack, SerialisedIota())
 		}
 	}
 
@@ -120,7 +122,7 @@ open class ProjectileWisp : BaseCastingWisp {
 		else {
 			val serStack = SerialisedIotaList(mutableListOf(EntityIota(this),
 					Vec3Iota(Vec3.atCenterOf(result.blockPos))).toNbtList())
-			scheduleCast(CASTING_SCHEDULE_PRIORITY, serHex, serStack)
+			scheduleCast(CASTING_SCHEDULE_PRIORITY, serHex, serStack, SerialisedIota())
 		}
 	}
 


### PR DESCRIPTION
This reworks SerializedIotas to seamlessly switch between serialized/unserialized representations as needed, including caching lists of referenced entities.

This also clears the stack/ravenmind when they get too large, using the detection routines from upstream HexCasting.