### PR TITLE
Wisp improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Added support for debugging cyclic wisps with [HexDebug](https://modrinth.com/mod/hexdebug)!
 - Added Gatekeeper's Purification to check whether a gate currently has a valid destination.
+- Added a mishap for trying to summon a wisp in an environment without a casting player.
 
 ### Changed
 
@@ -30,6 +31,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed the Trade spell requiring input items in a specific order for two-item trades.
 - Fixed broken/missing lang keys for `list.double` and `list.vec`.
 - Fixed wisps being able to generate infinite media by consuming themselves.
+- Fixed wisps being unable to access the offhand or inventory of their caster.
+- Fixed wisps without a caster being frozen forever.
 
 ## `0.3.1` - 2025-10-30
 

--- a/Common/src/main/java/ram/talia/hexal/api/casting/eval/env/WispCastEnv.kt
+++ b/Common/src/main/java/ram/talia/hexal/api/casting/eval/env/WispCastEnv.kt
@@ -67,21 +67,21 @@ class WispCastEnv(val wisp: BaseCastingWisp, level: ServerLevel) : CastingEnviro
     override fun getCastingHand(): InteractionHand = InteractionHand.MAIN_HAND
 
     override fun getUsableStacks(mode: StackDiscoveryMode): MutableList<ItemStack> {
-        if (wisp.caster != null)
-            return getUsableStacksForPlayer(mode, null, wisp.caster as ServerPlayer);
-        return mutableListOf()
+        return (wisp.caster as? ServerPlayer)
+            ?.let { getUsableStacksForPlayer(mode, null, it) }
+            ?: mutableListOf()
     }
 
     override fun getPrimaryStacks(): MutableList<HeldItemInfo> {
-        if (wisp.caster != null)
-            return getPrimaryStacksForPlayer(InteractionHand.OFF_HAND, wisp.caster as ServerPlayer);
-        return mutableListOf()
+        return (wisp.caster as? ServerPlayer)
+            ?.let { getPrimaryStacksForPlayer(InteractionHand.OFF_HAND, it) }
+            ?: mutableListOf()
     }
 
     override fun replaceItem(stackOk: Predicate<ItemStack>, replaceWith: ItemStack, hand: InteractionHand?): Boolean {
-        if (wisp.caster != null)
-            return replaceItemForPlayer(stackOk, replaceWith, hand, wisp.caster as ServerPlayer)
-        return false
+        return (wisp.caster as? ServerPlayer)
+            ?.let { replaceItemForPlayer(stackOk, replaceWith, hand, it) }
+            ?: false
     }
 
     override fun getPigment(): FrozenPigment = wisp.pigment()

--- a/Common/src/main/java/ram/talia/hexal/api/casting/eval/env/WispCastEnv.kt
+++ b/Common/src/main/java/ram/talia/hexal/api/casting/eval/env/WispCastEnv.kt
@@ -67,16 +67,21 @@ class WispCastEnv(val wisp: BaseCastingWisp, level: ServerLevel) : CastingEnviro
     override fun getCastingHand(): InteractionHand = InteractionHand.MAIN_HAND
 
     override fun getUsableStacks(mode: StackDiscoveryMode): MutableList<ItemStack> {
-        return mutableListOf() // TODO
+        if (wisp.caster != null)
+            return getUsableStacksForPlayer(mode, null, wisp.caster as ServerPlayer);
+        return mutableListOf()
     }
 
     override fun getPrimaryStacks(): MutableList<HeldItemInfo> {
-        return mutableListOf() // TODO
-
+        if (wisp.caster != null)
+            return getPrimaryStacksForPlayer(InteractionHand.OFF_HAND, wisp.caster as ServerPlayer);
+        return mutableListOf()
     }
 
     override fun replaceItem(stackOk: Predicate<ItemStack>, replaceWith: ItemStack, hand: InteractionHand?): Boolean {
-        return false // TODO
+        if (wisp.caster != null)
+            return replaceItemForPlayer(stackOk, replaceWith, hand, wisp.caster as ServerPlayer)
+        return false
     }
 
     override fun getPigment(): FrozenPigment = wisp.pigment()

--- a/Common/src/main/java/ram/talia/hexal/api/casting/mishaps/MishapNeedsCaster.kt
+++ b/Common/src/main/java/ram/talia/hexal/api/casting/mishaps/MishapNeedsCaster.kt
@@ -1,0 +1,16 @@
+package ram.talia.hexal.api.casting.mishaps
+
+import at.petrak.hexcasting.api.casting.eval.CastingEnvironment
+import at.petrak.hexcasting.api.casting.iota.Iota
+import at.petrak.hexcasting.api.casting.mishaps.Mishap
+import at.petrak.hexcasting.api.pigment.FrozenPigment
+import net.minecraft.network.chat.Component
+import net.minecraft.world.item.DyeColor
+
+class MishapNeedsCaster : Mishap() {
+    override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment = dyeColor(DyeColor.LIGHT_BLUE)
+
+    override fun errorMessage(env: CastingEnvironment, errorCtx: Context): Component = error("needs_caster", actionName(errorCtx.name))
+
+    override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {}
+}

--- a/Common/src/main/java/ram/talia/hexal/api/casting/mishaps/MishapNoWisp.kt
+++ b/Common/src/main/java/ram/talia/hexal/api/casting/mishaps/MishapNoWisp.kt
@@ -14,7 +14,7 @@ import net.minecraft.world.item.enchantment.EnchantmentHelper
 class MishapNoWisp : Mishap() {
 	override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment = dyeColor(DyeColor.LIGHT_BLUE)
 
-	override fun errorMessage(env: CastingEnvironment, errorCtx: Context): Component = error("no_wisp", actionName(errorCtx.name))
+	override fun errorMessage(env: CastingEnvironment, errorCtx: Context): Component = error("no_wisp")
 
 	private inline fun dropAll(player: Player, stacks: MutableList<ItemStack>, filter: (ItemStack) -> Boolean = { true }) {
 		for (index in stacks.indices) {

--- a/Common/src/main/java/ram/talia/hexal/api/casting/mishaps/MishapNonPlayer.kt
+++ b/Common/src/main/java/ram/talia/hexal/api/casting/mishaps/MishapNonPlayer.kt
@@ -12,7 +12,7 @@ import net.minecraft.world.item.DyeColor
 class MishapNonPlayer : Mishap() {
 	override fun accentColor(env: CastingEnvironment, errorCtx: Context): FrozenPigment = dyeColor(DyeColor.LIGHT_BLUE)
 
-	override fun errorMessage(env: CastingEnvironment, errorCtx: Context): Component = error("non_player", actionName(errorCtx.name))
+	override fun errorMessage(env: CastingEnvironment, errorCtx: Context): Component = error("non_player")
 
 	override fun execute(env: CastingEnvironment, errorCtx: Context, stack: MutableList<Iota>) {
 		env.caster?.addEffect(MobEffectInstance(MobEffects.BLINDNESS, 20 * 60))

--- a/Common/src/main/java/ram/talia/hexal/common/casting/actions/spells/wisp/OpSummonWisp.kt
+++ b/Common/src/main/java/ram/talia/hexal/common/casting/actions/spells/wisp/OpSummonWisp.kt
@@ -18,6 +18,7 @@ import ram.talia.hexal.api.HexalAPI
 import ram.talia.hexal.api.addBounded
 import ram.talia.hexal.api.casting.eval.env.WispCastEnv
 import ram.talia.hexal.api.casting.mishaps.MishapExcessiveReproduction
+import ram.talia.hexal.api.casting.mishaps.MishapNeedsCaster
 import ram.talia.hexal.api.config.HexalConfig
 import ram.talia.hexal.common.entities.ProjectileWisp
 import ram.talia.hexal.common.entities.TickingWisp
@@ -36,6 +37,10 @@ class OpSummonWisp(val ticking: Boolean) : SpellAction {
         val pos = args.getVec3(1, argc)
         val media: Double
         val cost: Long
+
+        if (env.castingEntity !is ServerPlayer) {
+            throw MishapNeedsCaster()
+        }
 
         if (env is WispCastEnv && env.wisp.summonedChildThisCast)
             throw MishapExcessiveReproduction(env.wisp) // wisps can only summon one child per cast.
@@ -76,7 +81,7 @@ class OpSummonWisp(val ticking: Boolean) : SpellAction {
             if (env is WispCastEnv)
                 env.wisp.summonedChildThisCast = true
 
-            val player = env.castingEntity as? ServerPlayer
+            val player = env.castingEntity as ServerPlayer
 
             val pigment = env.pigment
             val wisp = when (ticking) {
@@ -89,7 +94,7 @@ class OpSummonWisp(val ticking: Boolean) : SpellAction {
             env.world.addFreshEntity(wisp)
 
             // if the current cast is being debugged, try to spawn the wisp in debug mode too
-            if (HexDebugCoreAPI.INSTANCE.getDebugEnv(env) != null && player != null && wisp is TickingWisp) {
+            if (HexDebugCoreAPI.INSTANCE.getDebugEnv(env) != null && wisp is TickingWisp) {
                 val debugEnv = WispDebugEnv(player, wisp.uuid, ravenmind)
                 try {
                     HexDebugCoreAPI.INSTANCE.createDebugThread(debugEnv, null)

--- a/Common/src/main/java/ram/talia/hexal/common/casting/actions/spells/wisp/OpSummonWisp.kt
+++ b/Common/src/main/java/ram/talia/hexal/common/casting/actions/spells/wisp/OpSummonWisp.kt
@@ -38,9 +38,7 @@ class OpSummonWisp(val ticking: Boolean) : SpellAction {
         val media: Double
         val cost: Long
 
-        if (env.castingEntity !is ServerPlayer) {
-            throw MishapNeedsCaster()
-        }
+        val player = env.castingEntity as? ServerPlayer ?: throw MishapNeedsCaster()
 
         if (env is WispCastEnv && env.wisp.summonedChildThisCast)
             throw MishapExcessiveReproduction(env.wisp) // wisps can only summon one child per cast.
@@ -55,14 +53,14 @@ class OpSummonWisp(val ticking: Boolean) : SpellAction {
             true -> {
                 media = args.getPositiveDouble(2, argc)
                 cost = HexalConfig.server.summonTickingWispCost.addBounded((media * MediaConstants.DUST_UNIT).toLong())
-                Spell(true, pos, hex.toList(), ravenmind, (media * MediaConstants.DUST_UNIT).toLong())
+                Spell(player, true, pos, hex.toList(), ravenmind, (media * MediaConstants.DUST_UNIT).toLong())
             }
             false -> {
                 val vel = args.getVec3(2, argc)
                 media = args.getPositiveDouble(3, argc)
                 cost = max((HexalConfig.server.summonProjectileWispCost * vel.lengthSqr()).toLong(), HexalConfig.server.summonProjectileWispMinCost)
                             .addBounded((media * MediaConstants.DUST_UNIT).toLong())
-                Spell(false, pos, hex.toList(), ravenmind, (media * MediaConstants.DUST_UNIT).toLong(), vel)
+                Spell(player, false, pos, hex.toList(), ravenmind, (media * MediaConstants.DUST_UNIT).toLong(), vel)
             }
         }
 
@@ -75,13 +73,11 @@ class OpSummonWisp(val ticking: Boolean) : SpellAction {
         )
     }
 
-    private data class Spell(val ticking: Boolean, val pos: Vec3, val hex: List<Iota>, val ravenmind: Iota?, val media: Long, val vel: Vec3 = Vec3.ZERO) : RenderedSpell {
+    private data class Spell(val player: ServerPlayer, val ticking: Boolean, val pos: Vec3, val hex: List<Iota>, val ravenmind: Iota?, val media: Long, val vel: Vec3 = Vec3.ZERO) : RenderedSpell {
         override fun cast(env: CastingEnvironment) {
             // wisps can only summon one child per cast
             if (env is WispCastEnv)
                 env.wisp.summonedChildThisCast = true
-
-            val player = env.castingEntity as ServerPlayer
 
             val pigment = env.pigment
             val wisp = when (ticking) {

--- a/Common/src/main/java/ram/talia/hexal/common/entities/BaseCastingWisp.kt
+++ b/Common/src/main/java/ram/talia/hexal/common/entities/BaseCastingWisp.kt
@@ -144,7 +144,7 @@ abstract class BaseCastingWisp(entityType: EntityType<out BaseCastingWisp>, worl
 		}
 
 		// check if media is <= 0 ; destroy the wisp if it is, decrement the lifespan otherwise.
-		if (media <= 0) {
+		if (media <= 0 || casterUUID == null) {
 			discard()
 		}
 

--- a/Common/src/main/java/ram/talia/hexal/common/entities/BaseCastingWisp.kt
+++ b/Common/src/main/java/ram/talia/hexal/common/entities/BaseCastingWisp.kt
@@ -143,7 +143,7 @@ abstract class BaseCastingWisp(entityType: EntityType<out BaseCastingWisp>, worl
 			tryLoadTransferMediaFilters()
 		}
 
-		// check if media is <= 0 ; destroy the wisp if it is, decrement the lifespan otherwise.
+		// if media is <= 0 or caster uuid is missing, destroy the wisp; otherwise, continue processing
 		if (media <= 0 || casterUUID == null) {
 			discard()
 		}

--- a/Common/src/main/resources/assets/hexal/lang/en_us.json
+++ b/Common/src/main/resources/assets/hexal/lang/en_us.json
@@ -7,9 +7,9 @@
   "entity.hexal.wisp.ticking": "Cyclic Wisp",
   "entity.hexal.wisp.wandering": "Wandering Wisp",
 
-
-  "hexcasting.mishap.non_player": "%s expected to be cast by a player.",
-  "hexcasting.mishap.no_wisp": "%s expected to be cast by a wisp.",
+  "hexcasting.mishap.needs_caster": "Cannot be cast in a playerless context.",
+  "hexcasting.mishap.non_player": "Expected to be cast by a player.",
+  "hexcasting.mishap.no_wisp": "Expected to be cast by a wisp.",
   "hexcasting.mishap.others_wisp": "That wisp is owned by %s, not you.",
   "hexcasting.mishap.no_links": "%s has no links.",
   "hexcasting.mishap.self_link": "Tried to link %s to itself.",


### PR DESCRIPTION
- Fixes #200 
- Adds a new mishap for trying to summon a wisp in an environment without a casting player
- Causes existing wisps with no caster to immediately self-destruct