### PR TITLE
fix: temporary nexus binding should not overwrite permanent bind when given non-nexus position

### DIFF
--- a/Common/src/main/java/ram/talia/hexal/common/casting/actions/spells/motes/OpBindStorage.kt
+++ b/Common/src/main/java/ram/talia/hexal/common/casting/actions/spells/motes/OpBindStorage.kt
@@ -43,8 +43,14 @@ class OpBindStorage(private val isTemporaryBinding: Boolean) : SpellAction {
             val caster = env.caster ?: return null // TODO
 
             if (pos == null) {
-                if (!isTemporaryBinding) MediafiedItemManager.setBoundStorage(caster, null)
-                return null
+                if (!isTemporaryBinding) {
+                    MediafiedItemManager.setBoundStorage(caster, null)
+                    return null
+                } else {
+                    val userData = image.userData.copy()
+                    userData.remove(MoteIota.TAG_TEMP_STORAGE)
+                    return image.copy(userData = userData)
+                }
             }
 
             if (!env.canEditBlockAt(pos) || !IXplatAbstractions.INSTANCE.isInteractingAllowed(env.world, pos, Direction.UP, env.castingHand, env.caster))

--- a/Common/src/main/java/ram/talia/hexal/common/casting/actions/spells/motes/OpBindStorage.kt
+++ b/Common/src/main/java/ram/talia/hexal/common/casting/actions/spells/motes/OpBindStorage.kt
@@ -43,7 +43,7 @@ class OpBindStorage(private val isTemporaryBinding: Boolean) : SpellAction {
             val caster = env.caster ?: return null // TODO
 
             if (pos == null) {
-                MediafiedItemManager.setBoundStorage(caster, null)
+                if (!isTemporaryBinding) MediafiedItemManager.setBoundStorage(caster, null)
                 return null
             }
 


### PR DESCRIPTION
See pull request title.
It might be a good idea to also wipe any existing temporary bind, but I don't see too much utility in implementing that and  doing that would require more testing.
