### PR TITLE
Don't erase stack/raven if wisp's caster is in another dim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed wisps being able to generate infinite media by consuming themselves.
 - Fixed wisps being unable to access the offhand or inventory of their caster.
 - Fixed wisps without a caster being frozen forever.
+- Fixed wisps erasing their stack and ravenmind if loaded while their caster is in another dimension.
 - Fixed the Relay block not dropping when broken.
 - Fixed an error when a playerless caster tries to create a link.
 - Fixed an error when passing null or an empty mote to Use Item On.

--- a/Common/src/main/java/ram/talia/hexal/api/casting/wisp/WispCastingManager.kt
+++ b/Common/src/main/java/ram/talia/hexal/api/casting/wisp/WispCastingManager.kt
@@ -98,13 +98,8 @@ class WispCastingManager(private val casterUUID: UUID, private var cachedServer:
 			val wisp = cast.wisp ?: caster!!.serverLevel().getEntity(cast.wispUUID) as? BaseCastingWisp ?: continue
 			cast.wisp = wisp
 
-			if (wisp.isRemoved)
+			if (wisp.isRemoved || wisp.level().dimension() != caster?.level()?.dimension())
 				continue
-
-			if (wisp.level().dimension() != caster?.level()?.dimension()) {
-				wisp.castCallback(WispCastResult(wisp, false, mutableListOf(), CompoundTag(), true))
-				continue
-			}
 
 			results += cast(cast)
 


### PR DESCRIPTION
Fixes #181 